### PR TITLE
Switch to renderbag dxc-bin for shader compiler.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "thirdparty/fmt"]
 	path = thirdparty/fmt
 	url = https://github.com/fmtlib/fmt.git
+[submodule "thirdparty/dxc-bin"]
+	path = thirdparty/dxc-bin
+	url = https://github.com/renderbag/dxc-bin.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
 
-include($ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)
 set(CMAKE_CXX_STANDARD 17)
 
 project("XenosRecomp-ALL")

--- a/XenosRecomp/CMakeLists.txt
+++ b/XenosRecomp/CMakeLists.txt
@@ -18,11 +18,8 @@ add_executable(XenosRecomp
     shader_recompiler.h
     "${SMOLV_SOURCE_DIR}/smolv.cpp")
 
-find_package(directx-dxc CONFIG REQUIRED)
-
 target_link_libraries(XenosRecomp PRIVATE
     Microsoft::DirectXShaderCompiler
-    Microsoft::DXIL
     xxHash::xxhash
     libzstd_static
     fmt::fmt)
@@ -31,16 +28,26 @@ target_include_directories(XenosRecomp PRIVATE ${SMOLV_SOURCE_DIR})
 
 target_precompile_headers(XenosRecomp PRIVATE pch.h)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_compile_options(XenosRecomp PRIVATE -Wno-switch -Wno-unused-variable -Wno-null-arithmetic -fms-extensions)
+
+    include(CheckCXXSymbolExists)
+    check_cxx_symbol_exists(_LIBCPP_VERSION version LIBCPP)
+    if(LIBCPP)
+        # Allows using std::execution
+        target_compile_options(XenosRecomp PRIVATE -fexperimental-library)
+    endif()
 endif()
 
 if (WIN32)
     target_compile_definitions(XenosRecomp PRIVATE _CRT_SECURE_NO_WARNINGS)
-    find_file(DIRECTX_DXIL_LIBRARY "dxil.dll")
-    file(COPY ${DIRECTX_DXIL_LIBRARY} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+    add_custom_command(TARGET XenosRecomp POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:XenosRecomp> $<TARGET_FILE_DIR:XenosRecomp>
+        COMMAND_EXPAND_LISTS
+    )
 endif()
 
 if (XENOS_RECOMP_DXIL)
     target_compile_definitions(XenosRecomp PRIVATE XENOS_RECOMP_DXIL)
+    target_link_libraries(XenosRecomp PRIVATE Microsoft::DXIL)
 endif()

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -9,3 +9,7 @@ endif()
 if (NOT TARGET libzstd)
     add_subdirectory("${XENOS_RECOMP_THIRDPARTY_ROOT}/zstd/build/cmake")
 endif()
+
+if (NOT TARGET Microsoft::DirectXShaderCompiler)
+    add_subdirectory("${XENOS_RECOMP_THIRDPARTY_ROOT}/dxc-bin")
+endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,0 @@
-{
-    "builtin-baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f",
-    "dependencies": [
-        "directx-dxc"
-    ]
-}


### PR DESCRIPTION
Switches to the RT64 dxc-bin repo to get the DirectX shader compiler, instead of using vcpkg. Unlike the vcpkg package, this has macOS builds.

Included is also a small compiler options fix to compile on macOS.